### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           github_token: ${{ secrets.TOKEN }}
       - name: 'Create a Release'
-        uses: elgohr/Github-Release-Action@master
+        uses: elgohr/Github-Release-Action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
         with:


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore